### PR TITLE
Correção de seeds que quebraram com atualização do prisma.

### DIFF
--- a/apps/api/prisma/seed/fields.ts
+++ b/apps/api/prisma/seed/fields.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 export async function SeedFields(prisma: PrismaClient) {
-  const fields = [
+  const knowledgeAreas = [
     {
       name: 'Ciências Físicas, Matemática e Tecnologia',
     },
@@ -19,8 +19,8 @@ export async function SeedFields(prisma: PrismaClient) {
   ];
 
   try {
-    await prisma.tbField.createMany({
-      data: fields,
+    await prisma.knowledgeArea.createMany({
+      data: knowledgeAreas,
     });
     console.log('Tabela de Area preenchida com sucesso.');
   } catch (error) {

--- a/apps/api/prisma/seed/tags.ts
+++ b/apps/api/prisma/seed/tags.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 
 export async function SeedTags(prisma: PrismaClient) {
-  const tags = [
+  const keywords = [
     {
       name: 'Inteligência Artificial',
     },
@@ -26,12 +26,12 @@ export async function SeedTags(prisma: PrismaClient) {
   ];
 
   try {
-    await prisma.tbTags.createMany({
-      data: tags,
+    await prisma.keyword.createMany({
+      data: keywords,
     });
-    console.log('Tabela de Tags preenchida com sucesso.');
+    console.log('Tabela de Keywords preenchida com sucesso.');
   } catch (error) {
-    console.error('Falha ao preencher tabela de Tags.');
+    console.error('Falha ao preencher tabela de Keywords.');
     console.log(error.message);
   }
 }


### PR DESCRIPTION
## Problema
> Nest não sobe porque com atualização na definição das tabelas no prisma o seed ficou quebrado


## Esse PR faz:
> - [x] Renomeia entidades nos arquivos de seed de field e tag. Renomear os arquivos ficará para um próximo PR

