### PR TITLE
Research Group Get

### DIFF
--- a/apps/api/src/project/project.controller.ts
+++ b/apps/api/src/project/project.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { ProjectService } from './project.service';
+import { CreateProjectDto } from './project.dto';
+import { UpdateProjectDto } from './project.dto';
+
+@Controller('project')
+export class ProjectController {
+  constructor(private readonly projectService: ProjectService) {}
+
+  @Post()
+  create(@Body() createProjectDto: CreateProjectDto) {
+    return this.projectService.create(createProjectDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.projectService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.projectService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateProjectDto: UpdateProjectDto) {
+    return this.projectService.update(+id, updateProjectDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.projectService.remove(+id);
+  }
+}

--- a/apps/api/src/project/project.dto.ts
+++ b/apps/api/src/project/project.dto.ts
@@ -1,0 +1,1 @@
+export class CreateProjectDto {}

--- a/apps/api/src/project/project.module.ts
+++ b/apps/api/src/project/project.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ProjectService } from './project.service';
+import { ProjectController } from './project.controller';
+
+@Module({
+  controllers: [ProjectController],
+  providers: [ProjectService],
+})
+export class ProjectModule {}

--- a/apps/api/src/project/project.service.ts
+++ b/apps/api/src/project/project.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateProjectDto } from './project.dto';
+import { UpdateProjectDto } from './project.dto';
+
+@Injectable()
+export class ProjectService {
+  create(createProjectDto: CreateProjectDto) {
+    return 'This action adds a new project';
+  }
+
+  findAll() {
+    return `This action returns all project`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} project`;
+  }
+
+  update(id: number, updateProjectDto: UpdateProjectDto) {
+    return `This action updates a #${id} project`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} project`;
+  }
+}

--- a/apps/api/src/project/tests/project.controller.spec.ts
+++ b/apps/api/src/project/tests/project.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProjectController } from '../project.controller';
+import { ProjectService } from '../project.service';
+
+describe('ProjectController', () => {
+  let controller: ProjectController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProjectController],
+      providers: [ProjectService],
+    }).compile();
+
+    controller = module.get<ProjectController>(ProjectController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/api/src/project/tests/project.service.spec.ts
+++ b/apps/api/src/project/tests/project.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProjectService } from '../project.service';
+
+describe('ProjectService', () => {
+  let service: ProjectService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProjectService],
+    }).compile();
+
+    service = module.get<ProjectService>(ProjectService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/api/src/research-group/research-group.controller.ts
+++ b/apps/api/src/research-group/research-group.controller.ts
@@ -19,6 +19,11 @@ export class ResearchGroupController {
     return this.researchGroupsSevice.create(researchGroup);
   }
 
+  @Get()
+  findAll() {
+    return this.researchGroupsSevice.findAll();
+  }
+
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.researchGroupsSevice.findOne(id);

--- a/apps/api/src/research-group/research-group.service.ts
+++ b/apps/api/src/research-group/research-group.service.ts
@@ -8,6 +8,9 @@ import { CreateResearchGroupDto } from './research-group.dto';
 
 @Injectable()
 export class ResearchGroupService {
+  findAll() {
+    return this.prismaService.researchGroup.findMany();
+  }
   constructor(private readonly prismaService: PrismaService) {}
 
   async create(group: CreateResearchGroupDto) {


### PR DESCRIPTION
## Problema
> _ Controller de grupos de pesquisa ainda não possuiam o método get sem um id associado_   

> Exemplo: 
> - Para mostrar todos os grupos de pesquisa disponíveis na tela seria necessário pegar todos eles, não era possível.

## Esse PR faz:
> _Adiciona o método Get no controller de grupos de pesquisa, premitindo requisição de todos os grupos de pesquisa_  

