### PR TITLE
setup cypress tests with authentication as requirement

### DIFF
--- a/apps/web/api/http.service.ts
+++ b/apps/web/api/http.service.ts
@@ -1,6 +1,5 @@
-
 import { User } from "@/context/loginContext";
-import { loadUserFromLocalStorage } from "../lib/user.storage";
+import { loadUserFromLocalStorage } from "@/lib/user.storage";
 
 
 class HttpService {
@@ -52,7 +51,7 @@ class HttpService {
       });
     }
   
-    async delete<T>(endpoint: string): Promise<Response> {
+    async delete(endpoint: string): Promise<Response> {
       return this.request(endpoint, { method: "DELETE" });
     }
   }

--- a/apps/web/cypress/e2e/cadastro-demandas.cy.ts
+++ b/apps/web/cypress/e2e/cadastro-demandas.cy.ts
@@ -1,8 +1,12 @@
 import { FRONT_END_URL } from "./config";
+import {login} from "./setup.auth";
 
 describe('Just show page', () => {
 
   beforeEach(() => {
+
+    login("reginaldo.rossi@email.com.br", "mycrazysecurepassword");
+
     cy.visit(`${FRONT_END_URL}/cadastro-demandas`);
   });
 

--- a/apps/web/cypress/e2e/cadastro-projetos.cy.ts
+++ b/apps/web/cypress/e2e/cadastro-projetos.cy.ts
@@ -1,8 +1,10 @@
 import { FRONT_END_URL } from "./config";
+import { login } from "./setup.auth";
 
 describe('Just show page', () => {
 
   beforeEach(() => {
+    login("reginaldo.rossi@email.com.br", "mycrazysecurepassword");
     cy.visit(`${FRONT_END_URL}/cadastro-projetos`);
   });
 

--- a/apps/web/cypress/e2e/config.ts
+++ b/apps/web/cypress/e2e/config.ts
@@ -1,1 +1,2 @@
 export const FRONT_END_URL="http://localhost:3001"
+export const BACKEND_URL="http://localhost:8080"

--- a/apps/web/cypress/e2e/encontrar-demandas.cy.ts
+++ b/apps/web/cypress/e2e/encontrar-demandas.cy.ts
@@ -1,8 +1,10 @@
 import { FRONT_END_URL } from "./config";
+import { login } from "./setup.auth";
 
 describe('Just show page', () => {
 
   beforeEach(() => {
+    login("reginaldo.rossi@email.com.br", "mycrazysecurepassword");
     cy.visit(`${FRONT_END_URL}/encontrar-demandas`);
   });
 

--- a/apps/web/cypress/e2e/encontrar-grupo-pesquisa.cy.ts
+++ b/apps/web/cypress/e2e/encontrar-grupo-pesquisa.cy.ts
@@ -1,8 +1,10 @@
 import { FRONT_END_URL } from "./config";
+import { login } from "./setup.auth";
 
 describe('Just show page', () => {
 
   beforeEach(() => {
+    login("reginaldo.rossi@email.com.br", "mycrazysecurepassword");
     cy.visit(`${FRONT_END_URL}/encontrar-grupo-pesquisa`);
   });
 

--- a/apps/web/cypress/e2e/minhas-demandas.cy.ts
+++ b/apps/web/cypress/e2e/minhas-demandas.cy.ts
@@ -1,8 +1,10 @@
 import { FRONT_END_URL } from "./config";
+import { login } from "./setup.auth";
 
 describe('Just show page', () => {
 
   beforeEach(() => {
+    login("reginaldo.rossi@email.com.br", "mycrazysecurepassword");
     cy.visit(`${FRONT_END_URL}/minhas-demandas`);
   });
 

--- a/apps/web/cypress/e2e/minhas-propostas.cy.ts
+++ b/apps/web/cypress/e2e/minhas-propostas.cy.ts
@@ -1,8 +1,10 @@
 import { FRONT_END_URL } from "./config";
+import { login } from "./setup.auth";
 
 describe('Just show page', () => {
 
   beforeEach(() => {
+    login("reginaldo.rossi@email.com.br", "mycrazysecurepassword");
     cy.visit(`${FRONT_END_URL}/minhas-propostas`);
   });
 

--- a/apps/web/cypress/e2e/setup.auth.ts
+++ b/apps/web/cypress/e2e/setup.auth.ts
@@ -1,0 +1,19 @@
+import {BACKEND_URL} from "./config";
+
+export function login(email: string, password: string) {
+    
+    const options = {
+        method: "POST",
+        url: BACKEND_URL + "/auth/login",
+        body: {
+            email: email,
+            password: password
+        },
+        headers: {
+            "Content-Type": "application/json",
+        },
+    }
+    cy.request(options).then((response) => {
+        localStorage.setItem("user", JSON.stringify(response.body))
+    })
+}


### PR DESCRIPTION
## Problema
> Algumas telas requerem autenticação para serem testadas. Então, adiciona-se uma função que salva informações de um usuário autenticado no localStorage antes de qualquer acesso, para que não precise usar recursos de mock no front e permitir o teste de ponta a ponta.

## Esse PR faz:
> - [x] Algumas alterações de clean code
> - [x] função de setup no cypress
