### PR TITLE
Ajustes na tela de detalhamento de Grupo de Pesquisa

### DIFF
--- a/apps/web/modules/detalhe-grupo-pesquisa/components/projectsSection.tsx
+++ b/apps/web/modules/detalhe-grupo-pesquisa/components/projectsSection.tsx
@@ -22,10 +22,11 @@ export default function ProjectsSection(props: TProps) {
             <TableHead className="text-blue-strong font-semibold text-lg sm:text-2xl">
               Nome
             </TableHead>
-
+            {/*
             <TableHead className="text-blue-strong font-semibold text-lg sm:text-2xl">
               Status
             </TableHead>
+            */}
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -35,9 +36,11 @@ export default function ProjectsSection(props: TProps) {
                 <TableCell className="text-blue-light py-6">
                   {project.name}
                 </TableCell>
+                {/*
                 <TableCell className="text-blue-light py-6">
                   {project.finished_at ?? "Em andamento"}
                 </TableCell>
+                */}
               </TableRow>
             );
           })}

--- a/apps/web/modules/detalhe-grupo-pesquisa/detalheGrupoPesquisaPage.tsx
+++ b/apps/web/modules/detalhe-grupo-pesquisa/detalheGrupoPesquisaPage.tsx
@@ -26,7 +26,7 @@ export default function DetalheGrupoPesquisaPage() {
   const router = useRouter();
   const groupId = params.id;
 
-  const [selectedTab, setSelectedTab] = React.useState<ETabs>(ETabs.MEMBERS);
+  const [selectedTab, setSelectedTab] = React.useState<ETabs>(ETabs.PROJECTS);
 
   const {
     data: researchGroup,
@@ -104,19 +104,19 @@ export default function DetalheGrupoPesquisaPage() {
               <Button
                 className="rounded-full"
                 onClick={() => {
-                  handleTabChange(ETabs.MEMBERS);
+                  handleTabChange(ETabs.PROJECTS);
                 }}
               >
-                Lista de Membros
+                Projetos
               </Button>
 
               <Button
                 className="rounded-full"
                 onClick={() => {
-                  handleTabChange(ETabs.PROJECTS);
+                  handleTabChange(ETabs.MEMBERS);
                 }}
               >
-                Lista de Projetos
+                Membros
               </Button>
             </div>
             {researchGroup ? (


### PR DESCRIPTION
## Problema
Necessidade de ajustes na tela de detalhamento do grupo de pesquisa. 

## Esse PR faz:
Atende a issue #174 , removendo o termo `lista` da lista de membros e lista de projetos. Remove a coluna status da listagem de projetos.
