### PR TITLE
[FRONT] ISSUE 188 - Adicionei keywords na lista de projeto do grupo

### DIFF
--- a/apps/api/src/research-group/research-group.service.ts
+++ b/apps/api/src/research-group/research-group.service.ts
@@ -139,7 +139,11 @@ export class ResearchGroupService {
       },
       include: {
         leader: true,
-        projects: true,
+        projects: {
+          include: {
+            keywords: true,
+          },
+        },
         members: {
           include: {
             user: {

--- a/apps/web/modules/detalhe-grupo-pesquisa/components/projectsSection.tsx
+++ b/apps/web/modules/detalhe-grupo-pesquisa/components/projectsSection.tsx
@@ -20,13 +20,17 @@ export default function ProjectsSection(props: TProps) {
         <TableHeader>
           <TableRow>
             <TableHead className="text-blue-strong font-semibold text-lg sm:text-2xl">
-              Nome
+              Título
             </TableHead>
             {/*
             <TableHead className="text-blue-strong font-semibold text-lg sm:text-2xl">
               Status
             </TableHead>
             */}
+
+            <TableHead className="text-blue-strong font-semibold text-lg sm:text-2xl">
+              Palavras-Chaves
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -35,6 +39,21 @@ export default function ProjectsSection(props: TProps) {
               <TableRow>
                 <TableCell className="text-blue-light py-6">
                   {project.name}
+                </TableCell>
+                {/*
+                <TableCell className="text-blue-light py-6">
+                  {project.finished_at ?? "Em andamento"}
+                </TableCell>
+                */}
+
+                <TableCell className="text-blue-light py-6">
+                  {project.keywords.map((keyword) => {
+                    return (
+                      <span className="mr-2 text-blue-light bg-primary text-primary-foreground p-2 rounded-2xl">
+                        {keyword.name ? keyword.name : "N/A"}
+                      </span>
+                    );
+                  })}
                 </TableCell>
               </TableRow>
             );

--- a/apps/web/modules/detalhe-grupo-pesquisa/types/researchgroup.type.ts
+++ b/apps/web/modules/detalhe-grupo-pesquisa/types/researchgroup.type.ts
@@ -14,13 +14,21 @@ export type TUser = {
   email: string;
 };
 
+export type TKeyword = {
+  id: string;
+  name: string;
+};
+
 export type TProject = {
   id: string;
   name: string;
+  started_at: string;
+  finished_at: string | null;
   researchGroupId: string;
   demandId: string | null;
   createdAt: string;
   updatedAt: string;
+  keywords: TKeyword[];
 };
 
 export type TMember = {


### PR DESCRIPTION
## Problema
> A listagem de projeto dentro da tela de detalhamento de grupo de pesquisa não estava exibindo as keywords do projeto.

## Esse PR faz:
> Alterei na tabela de projeto "nome" para "titulo".
> Atualizei endpoint do backend para retornar as keywords do projeto.
> Adicionei as palavras-chaves a listagem de projeto.

## Pendencias
> Adicionar link do projeto a tabela de projetos do grupo.

